### PR TITLE
A package.main can contain a reference to a dir

### DIFF
--- a/src/main/javascript/npm_modules.js
+++ b/src/main/javascript/npm_modules.js
@@ -137,7 +137,7 @@
       try {
         var body = readFile(file.getCanonicalPath()),
             package  = JSON.parse(body);
-        return resolveAsFile(package.main || 'index.js', base);
+        return resolveAsFile(package.main || 'index.js', base, '/');
       } catch(ex) {
         throw new ModuleError("Cannot load JSON file", "PARSE_ERROR", ex);
       }
@@ -207,4 +207,3 @@
   ModuleError.prototype = new Error();
   ModuleError.prototype.constructor = ModuleError;
 }());
-


### PR DESCRIPTION
Without a addition of '/' as ext, this case it to look for /lib.js

NOTE: quick hack. I don't know the npm spec etc, but this made it work for me :)
