### PR TITLE
Update jvm-npm.js

### DIFF
--- a/src/main/javascript/jvm-npm.js
+++ b/src/main/javascript/jvm-npm.js
@@ -218,7 +218,7 @@ module = (typeof module == 'undefined') ? {} :  module;
 
   function resolveAsFile(id, root, ext) {
     var file;
-    if ( id.indexOf('/') === 0 ) {
+    if ( id.length > 0 && id[0] === '/' ) {
       file = new File(normalizeName(id, ext || '.js'));
       if (!file.exists()) {
         return resolveAsDirectory(id);


### PR DESCRIPTION
Just a recommendation. I believe using indexOf would unnecessarily go through each character in the string until it finds the character. If your purpose is to check if the string starts with a '\', I guess manually checking the first index might be a better idea.