### PR TITLE
Call `getResource` i.s.o. `findResource` (fixes #17)

### DIFF
--- a/src/main/javascript/jvm-npm.js
+++ b/src/main/javascript/jvm-npm.js
@@ -237,7 +237,7 @@ module = (typeof module == 'undefined') ? {} :  module;
   function resolveCoreModule(id, root) {
     var name = normalizeName(id);
     var classloader = java.lang.Thread.currentThread().getContextClassLoader();
-    if (classloader.findResource(name))
+    if (classloader.getResource(name))
         return { path: name, core: true };
   }
 


### PR DESCRIPTION
`ClassLoader.findResource` is protected. On WildFly at least, the context classloader has a `findResource` method that needs 2 parameters. Changing to `getResource` seems to fix this issue.
https://github.com/nodyn/jvm-npm/issues/17