### PR TITLE
fixed conversion from module-id to path-parts not working on backslashes

### DIFF
--- a/src/main/javascript/jvm-npm.js
+++ b/src/main/javascript/jvm-npm.js
@@ -173,7 +173,7 @@ module = (typeof module == 'undefined') ? {} :  module;
 
   function findRoot(parent) {
     if (!parent || !parent.id) { return Require.root; }
-    var pathParts = parent.id.split('/');
+    var pathParts = parent.id.split(/[\/|\\,]+/g);
     pathParts.pop();
     return pathParts.join('/');
   }


### PR DESCRIPTION
I am using jvm-npm with nashorn on Windows 10 and Java 1.8.
The "findRoot" function does not handle backslashes in the module-id. This causes code like...
    require('lib/some_module.js');

...not to work even though the module is there and all paths are correctly specified.
This happens because internally the module-id on Windows uses backslashes instead of forward slashes.

A different solution could be to normalize the paths to forward slashes at the right points.