### PR TITLE
Fix resolving modules with .js in module name

### DIFF
--- a/src/main/javascript/jvm-npm.js
+++ b/src/main/javascript/jvm-npm.js
@@ -194,8 +194,8 @@ module = (typeof module == 'undefined') ? {} :  module;
 
   function resolveAsNodeModule(id, root) {
     var base = [root, 'node_modules'].join('/');
-    return resolveAsFile(id, base) ||
-      resolveAsDirectory(id, base) ||
+    return resolveAsDirectory(id, base) ||
+      resolveAsFile(id, base) ||
       (root ? resolveAsNodeModule(id, new File(root).getParent()) : false);
   }
 


### PR DESCRIPTION
When using nashorn and loading a script with a dependency to a node
module that contains .js in its name e.g. decimal.js, the actual js
file inside the module couldn't be resolved.

The fix is achieved by trying to resolve to directory first and then
to file.